### PR TITLE
Fix Markdown level 3 title

### DIFF
--- a/src/main/java/io/github/robwin/markup/builder/markdown/Markdown.java
+++ b/src/main/java/io/github/robwin/markup/builder/markdown/Markdown.java
@@ -31,7 +31,7 @@ public enum Markdown implements Markup {
     DOCUMENT_TITLE("# "),
     SECTION_TITLE_LEVEL1("## "),
     SECTION_TITLE_LEVEL2("### "),
-    SECTION_TITLE_LEVEL3("### "),
+    SECTION_TITLE_LEVEL3("#### "),
     BOLD("**"),
     ITALIC("*"),
     LIST_ENTRY("* ");


### PR DESCRIPTION
The level 3 title of Markdown was missing a #, leading to weird TOC when generating other output formats based on md.
